### PR TITLE
Change default port to 12111

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go get -u github.com/brandur/stripelocal
 Run it:
 
 ``` sh
-stripelocal -port 12111
+stripelocal
 ```
 
 Then from another terminal:
@@ -32,6 +32,9 @@ Then from another terminal:
 ``` sh
 curl -i http://localhost:12111/v1/charges
 ```
+
+By default, stripelocal runs on port 12111, but is configurable with the
+`-port` option.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ go get -u github.com/brandur/stripelocal
 Run it:
 
 ``` sh
-stripelocal -port 6065
+stripelocal -port 12111
 ```
 
 Then from another terminal:
 
 ``` sh
-curl -i http://localhost:6065/v1/charges
+curl -i http://localhost:12111/v1/charges
 ```
 
 ## Development

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -30,7 +30,7 @@ brew:
         <array>
           <string>#{opt_bin}/stripelocal</string>
           <string>-port</string>
-          <string>6065</string>
+          <string>12111</string>
         </array>
         <key>RunAtLoad</key>
         <true/>

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brandur/stripelocal/spec"
 )
 
-const defaultPort = 6065
+const defaultPort = 12111
 
 // verbose tracks whether the program is operating in verbose mode
 var verbose bool


### PR DESCRIPTION
Port 6065 should have been relatively uncontentious, but just to try and
keep collisions to an absolute mininum, I picked an unassigned port from
this list [1] maintained by the IANA.

[1] https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?&page=120